### PR TITLE
Fix display for gallery images

### DIFF
--- a/template.txt
+++ b/template.txt
@@ -23,6 +23,9 @@ cover: //img[has-class("wp-post-image")]
 @remove: //article/header
 @remove: //article/footer
 
+# Fix gallery <figure>
+@split_parent: //figure[has-class("wp-block-image")]
+
 # Replace p to figure
 @replace_tag(<figure>): $body//p[.//img]
 


### PR DESCRIPTION
Template displayed only 1st image from embedded gallery, now it displays all images inlined.

Before:
![image](https://user-images.githubusercontent.com/8038470/186613807-aab9899e-7354-4118-9916-bc8a3558bcb1.png)

After:
![image](https://user-images.githubusercontent.com/8038470/186613950-84e0d640-fdd6-4738-a56b-e77959b47aee.png)
